### PR TITLE
docs: add video on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Visualizing the evolution of topics extracted from HIDIVE Lab publication titles
 - 'Read more' when the author list becomes too long
 - Hovering upon legend text for its list of venues
 - The background in the header also resembles a stream~~
+
+[HIDIVE-WordStream.mov](media%2FHIDIVE-WordStream.mov)

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Visualizing the evolution of topics extracted from HIDIVE Lab publication titles
 - Hovering upon legend text for its list of venues
 - The background in the header also resembles a stream~~
 
-[HIDIVE-WordStream.mov](media%2FHIDIVE-WordStream.mov)
+<video src="https://github.com/user-attachments/assets/cc635db9-3ab1-45d2-8624-9f245bfe37d0" width="352" height="720"></video>

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Visualizing the evolution of topics extracted from HIDIVE Lab publication titles
 - Hovering upon legend text for its list of venues
 - The background in the header also resembles a stream~~
 
-<video src="https://github.com/user-attachments/assets/cc635db9-3ab1-45d2-8624-9f245bfe37d0" width="352" height="720"></video>
+<video src="https://github.com/user-attachments/assets/cc635db9-3ab1-45d2-8624-9f245bfe37d0"></video>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hidive-wordstream
 
-Visualizing the evolution of topics extracted from HIDIVE Lab publication titles over time. Written in vanilla JS and D3.
+Visualizing the evolution of topics extracted from HIDIVE Lab *publication titles* over time. Written in vanilla JS and D3.
 
 
 **Play around at:** https://huyen-nguyen.github.io/hidive-wordstream/
@@ -11,9 +11,9 @@ Visualizing the evolution of topics extracted from HIDIVE Lab publication titles
 - The font size of each word reflects its frequency, while the stream height represents the number of publications.
 - You can click on any word to track its usage trend over time, which will also filter the underlying data table for more detailed analysis.
 
-**Little nuggets that I like**
+**Little nuggets that I like:**
 - 'Read more' when the author list becomes too long
-- Hovering upon legend text for its list of venues
-- The background in the header also resembles a stream~~
+- Hovering over the legend text opens up a list of venues
+- The background in the header resembles a flowing stream~
 
 <video src="https://github.com/user-attachments/assets/cc635db9-3ab1-45d2-8624-9f245bfe37d0"></video>


### PR DESCRIPTION
First- upload to GitHub issue to get a link like this (https://github.com/user-attachments/assets/cc635db9-3ab1-45d2-8624-9f245bfe37d0)

Second- embed in README: `<video src="https://github.com/user-attachments/assets/cc635db9-3ab1-45d2-8624-9f245bfe37d0"></video>`

Result: 
<video src="https://github.com/user-attachments/assets/cc635db9-3ab1-45d2-8624-9f245bfe37d0"></video>